### PR TITLE
ci: add Windows ARM64 build support in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
           - platform: 'ubuntu-24.04'
           - platform: 'ubuntu-24.04-arm' # for Arm based linux.
           - platform: 'windows-latest'
+          - platform: 'windows-11-arm' # for Windows ARM64
+            args: '--target aarch64-pc-windows-msvc'
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -73,6 +75,10 @@ jobs:
 
       - name: Prebuild
         run: make prebuild
+
+      - name: Add rust target
+        if: matrix.args != null
+        run: rustup target add $(echo "${{ matrix.args }}" | cut -d' ' -f2)
 
       - name: Build the app
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
- Add windows-11-arm runner to matrix for aarch64-pc-windows-msvc
- Add rustup target add step for cross-compilation targets

Previously the Windows ARM64 entry used windows-latest (x64 runner) which cannot produce correct ARM64 artifacts. windows-11-arm is the correct native ARM64 runner.

Fixes the issue reported by @0xbrayo in PR #80.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Windows ARM64 build support to the release process, enabling cross-compilation for ARM-based Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->